### PR TITLE
Addressed the omission of consideration of ClassicEC2 in SecurityGroup.

### DIFF
--- a/cmd/vaws/root.go
+++ b/cmd/vaws/root.go
@@ -11,7 +11,7 @@ var rootCmd = &cobra.Command{
 	Use:     "vaws",
 	Short:   "The vaws command was created to simplify the display of AWS resources.",
 	Long:    `The vaws command was created to simplify the display of AWS resources.`,
-	Version: "0.3.0",
+	Version: "0.3.1",
 }
 
 func Execute() {

--- a/cmd/vaws/security_group.go
+++ b/cmd/vaws/security_group.go
@@ -79,8 +79,14 @@ func showSecurityGroup(outputs []*ec2.DescribeSecurityGroupsOutput, table *table
 	table.SetHeader(header)
 	var records [][]string
 	var allowPort int32
+	var vpcId string
 	for _, o := range outputs {
 		for _, sg := range o.SecurityGroups {
+			if sg.VpcId == nil {
+				vpcId = "none"
+			} else {
+				vpcId = *sg.VpcId
+			}
 			for _, in := range sg.IpPermissions {
 				allowType := "inbound"
 				if in.ToPort != nil {
@@ -96,7 +102,7 @@ func showSecurityGroup(outputs []*ec2.DescribeSecurityGroupsOutput, table *table
 							*sg.GroupId,
 							strconv.Itoa(int(allowPort)),
 							*v.CidrIp,
-							*sg.VpcId,
+							vpcId,
 						})
 					}
 				}
@@ -108,7 +114,7 @@ func showSecurityGroup(outputs []*ec2.DescribeSecurityGroupsOutput, table *table
 							*sg.GroupId,
 							strconv.Itoa(int(allowPort)),
 							*prefix.PrefixListId,
-							*sg.VpcId,
+							vpcId,
 						})
 					}
 				}
@@ -120,7 +126,7 @@ func showSecurityGroup(outputs []*ec2.DescribeSecurityGroupsOutput, table *table
 							*sg.GroupId,
 							strconv.Itoa(int(allowPort)),
 							*v.GroupId,
-							*sg.VpcId,
+							vpcId,
 						})
 					}
 				}

--- a/cmd/vaws/security_group_test.go
+++ b/cmd/vaws/security_group_test.go
@@ -127,6 +127,57 @@ func Test_showSecurityGroup(t *testing.T) {
 `,
 		},
 		{
+			name: "classic ec2",
+			args: args{
+				outputs: []*ec2.DescribeSecurityGroupsOutput{
+					{
+						SecurityGroups: []types.SecurityGroup{
+							{
+								GroupName: aws.String("default"),
+								GroupId:   aws.String("sg-0d642190887707fd0"),
+								VpcId:     nil,
+								IpPermissions: []types.IpPermission{
+									{
+										IpRanges: []types.IpRange{
+											{
+												CidrIp: aws.String("0.0.0.0/0"),
+											},
+										},
+										ToPort: nil,
+									},
+								},
+							},
+							{
+								GroupName: aws.String("launch-wizard-1"),
+								GroupId:   aws.String("sg-0d642190887707fd0"),
+								VpcId:     aws.String("vpc-0f9999c7db8c44b21"),
+								IpPermissions: []types.IpPermission{
+									{
+										IpRanges: []types.IpRange{
+											{
+												CidrIp: aws.String("0.0.0.0/0"),
+											},
+										},
+										ToPort: aws.Int32(22),
+									},
+								},
+							},
+						},
+						ResultMetadata: middleware.Metadata{},
+					},
+				},
+				table:        nil,
+				sortPosition: 1,
+			},
+			want: `+-----------------+---------+----------------------+------+-----------+-----------------------+
+|      NAME       |  TYPE   |          ID          | PORT |  SOURCE   |          VPC          |
++-----------------+---------+----------------------+------+-----------+-----------------------+
+| default         | inbound | sg-0d642190887707fd0 |   -1 | 0.0.0.0/0 | none                  |
+| launch-wizard-1 | inbound | sg-0d642190887707fd0 |   22 | 0.0.0.0/0 | vpc-0f9999c7db8c44b21 |
++-----------------+---------+----------------------+------+-----------+-----------------------+
+`,
+		},
+		{
 			name: "sort_port",
 			args: args{
 				outputs: []*ec2.DescribeSecurityGroupsOutput{


### PR DESCRIPTION
Classic EC2の場合はsg.VpcIdがnilとなる。
そこを参照しようとしてエラー落ちするのを対応。